### PR TITLE
[SearXNG PR-3116] Block HeadlessChrome

### DIFF
--- a/src/botdetection/http_user_agent.py
+++ b/src/botdetection/http_user_agent.py
@@ -35,7 +35,7 @@ USER_AGENT = (
     + r'|HttpClient|Jersey|Python|libwww-perl|Ruby|SynHttpClient|UniversalFeedParser|Googlebot|GoogleImageProxy'
     + r'|bingbot|Baiduspider|yacybot|YandexMobileBot|YandexBot|Yahoo! Slurp|MJ12bot|AhrefsBot|archive.org_bot|msnbot'
     + r'|MJ12bot|SeznamBot|linkdexbot|Netvibes|SMTBot|zgrab|James BOT|Sogou|Abonti|Pixray|Spinn3r|SemrushBot|Exabot'
-    + r'|ZmEu|BLEXBot|bitlybot'
+    + r'|ZmEu|BLEXBot|bitlybot|HeadlessChrome'
     # unmaintained Farside instances
     + r'|'
     + re.escape(r'Mozilla/5.0 (compatible; Farside/0.1.0; +https://farside.link)')


### PR DESCRIPTION
This patch moves the [PR-3116] from the SearXNG reposetory to this fork of the botdetection package.

The origin is from @unixfox see commit [SearXNG 8efc091].

[PR-3116] https://github.com/searxng/searxng/pull/3116 
[SearXNG 8efc091] https://github.com/searxng/searxng/pull/3116/commits/8efc091